### PR TITLE
Feature/blank select option

### DIFF
--- a/androidvalidatedforms/src/main/java/com/azavea/androidvalidatedforms/controllers/SelectionController.java
+++ b/androidvalidatedforms/src/main/java/com/azavea/androidvalidatedforms/controllers/SelectionController.java
@@ -98,6 +98,11 @@ public class SelectionController extends LabeledFieldController {
                     }
                 }
 
+                // allow empty string values to be used to represent empty selection on non-required fields
+                if (!isRequired() && value != null && value.equals("")) {
+                    value = null;
+                }
+
                 getModel().setValue(getName(), value);
             }
 

--- a/sample/src/main/java/com/azavea/androidvalidatedforms/sample/RecordFormActivity.java
+++ b/sample/src/main/java/com/azavea/androidvalidatedforms/sample/RecordFormActivity.java
@@ -73,7 +73,8 @@ public class RecordFormActivity extends FormWithAppCompatActivity implements For
         colors.add("yellow");
         colors.add("fuscia");
 
-        ArrayList<String> truthiness = new ArrayList<>(2);
+        ArrayList<String> truthiness = new ArrayList<>(3);
+        truthiness.add("");
         truthiness.add("yes");
         truthiness.add("no");
 
@@ -81,7 +82,7 @@ public class RecordFormActivity extends FormWithAppCompatActivity implements For
                 false, "Select", colors, colors));
 
         section.addElement(new SelectionController(this, "Truthiness", "yes or no?",
-                true, "Select", truthiness, truthiness));
+                false, "Select", truthiness, truthiness));
 
         section.addElement(new DatePickerController(this, "When", "Some date", true, true));
 

--- a/sample/src/main/java/com/azavea/androidvalidatedforms/sample/RecordFormActivity.java
+++ b/sample/src/main/java/com/azavea/androidvalidatedforms/sample/RecordFormActivity.java
@@ -66,15 +66,22 @@ public class RecordFormActivity extends FormWithAppCompatActivity implements For
         section.addElement(new EditTextController(this, "FirstName", "first name", "first name", true));
         section.addElement(new EditTextController(this, "LastName", "last name", "last name", true));
 
-        ArrayList<String> colors = new ArrayList<>(3);
+        ArrayList<String> colors = new ArrayList<>(5);
         colors.add("red");
         colors.add("blue");
         colors.add("green");
         colors.add("yellow");
         colors.add("fuscia");
 
+        ArrayList<String> truthiness = new ArrayList<>(2);
+        truthiness.add("yes");
+        truthiness.add("no");
+
         section.addElement(new SelectionController(this, "FavoriteColor", "favorite color",
-                true, "Select", colors, colors));
+                false, "Select", colors, colors));
+
+        section.addElement(new SelectionController(this, "Truthiness", "yes or no?",
+                true, "Select", truthiness, truthiness));
 
         section.addElement(new DatePickerController(this, "When", "Some date", true, true));
 

--- a/sample/src/main/java/com/azavea/androidvalidatedforms/sample/TestModel.java
+++ b/sample/src/main/java/com/azavea/androidvalidatedforms/sample/TestModel.java
@@ -20,6 +20,8 @@ public class TestModel {
 
     public String FavoriteColor;
 
+    public String Truthiness;
+
     public Date When;
 
     public ImageHolder Pic;


### PR DESCRIPTION
Allow empty string for no selection.

In non-required select fields, treat an empty string value as null. Cannot use null, as object with `equals` and `toString` needed.
